### PR TITLE
Fixes to jamf_postinstall_script_for_nice_updater.sh

### DIFF
--- a/jamf_postinstall_script_for_nice_updater.sh
+++ b/jamf_postinstall_script_for_nice_updater.sh
@@ -42,7 +42,7 @@ if [[ -f "$customIconPath" ]]; then
     cp "$customIconPath" /Library/Scripts/nice_updater_custom_icon.png
     chown root:wheel /Library/Scripts/nice_updater_custom_icon.png
     chmod 644 /Library/Scripts/nice_updater_custom_icon.png
-    [[ $customIconPath ]] && defaults write "$preferenceFileFullPath" IconCustomPath -string "$customIconPath" 
+    [[ $customIconPath ]] && defaults write "$preferenceFileFullPath" IconCustomPath -string "/Library/Scripts/nice_updater_custom_icon.png" 
 fi
 
 # update the start time intervals

--- a/jamf_postinstall_script_for_nice_updater.sh
+++ b/jamf_postinstall_script_for_nice_updater.sh
@@ -9,9 +9,9 @@
 # 5  - Start interval (minute of the hour), e.g. 45 = 45 mins past the hour, e.g. 13:45
 # 6  - Alert timeout in seconds. The time that the alert should stay on the screen
 #          (should be less than the start interval)
-# 7  - Max number of deferrals (default is 11 so first message says "10 remaining alerts")
+# 7  - Max number of deferrals (default is 8 so first message says "7 remaining alerts")
 # 8  - Number of days to wait after an empty software update run (default is 3)
-# 9  - Number of days to wait after a full software update is carried out (default is 14)
+# 9  - Number of days to wait after a full software update is carried out (default is 7)
 # 10 - Custom icon path - must exist on the device before the policy is run
 
 [[ $4 ]] && startIntervalHour=$4

--- a/jamf_postinstall_script_for_nice_updater.sh
+++ b/jamf_postinstall_script_for_nice_updater.sh
@@ -42,7 +42,7 @@ if [[ -f "$customIconPath" ]]; then
     cp "$customIconPath" /Library/Scripts/nice_updater_custom_icon.png
     chown root:wheel /Library/Scripts/nice_updater_custom_icon.png
     chmod 644 /Library/Scripts/nice_updater_custom_icon.png
-    [[ $customIconPath ]] && defaults write "$preferenceFileFullPath" IconCustomPath -string "customIconPath" 
+    [[ $customIconPath ]] && defaults write "$preferenceFileFullPath" IconCustomPath -string "$customIconPath" 
 fi
 
 # update the start time intervals

--- a/jamf_postinstall_script_for_nice_updater.sh
+++ b/jamf_postinstall_script_for_nice_updater.sh
@@ -42,6 +42,7 @@ if [[ -f "$customIconPath" ]]; then
     cp "$customIconPath" /Library/Scripts/nice_updater_custom_icon.png
     chown root:wheel /Library/Scripts/nice_updater_custom_icon.png
     chmod 644 /Library/Scripts/nice_updater_custom_icon.png
+    [[ $customIconPath ]] && defaults write "$preferenceFileFullPath" IconCustomPath -string "customIconPath" 
 fi
 
 # update the start time intervals


### PR DESCRIPTION
1. Adjust default deferral examples to current values
2. Fixed icon not being added to prefs.plist when custom icon specified (and copied)